### PR TITLE
Serve index files from subdirectories instead of root index

### DIFF
--- a/cypress/e2e/subdirectory-index.cy.ts
+++ b/cypress/e2e/subdirectory-index.cy.ts
@@ -1,0 +1,25 @@
+import {TestHarness} from './harness';
+import {ContentNode, TopologyNode} from './nodes';
+
+it('subdirectories with index.html', () => {
+  const projectId = 'test-proj';
+  const content0 = new ContentNode('content0', projectId, 'subdirectory-index');
+  const topology0 = new TopologyNode('topology0', [content0]);
+
+  const harness = new TestHarness(projectId, [topology0], [content0]);
+  harness.intercept();
+
+  cy.visit(harness.domainNode.url);
+  cy.get('h1').first().should('have.text', 'root index.html');
+
+  // With trailing slash
+  cy.get('a[href="/blog/"]').first().click();
+  cy.get('h1').first().should('have.text', 'blog index.html');
+
+  cy.go('back');
+  cy.get('h1').first().should('have.text', 'root index.html');
+
+  // Without trailing slash
+  cy.get('a[href="/blog"]').first().click();
+  cy.get('h1').first().should('have.text', 'blog index.html');
+});

--- a/cypress/fixtures/subdirectory-index/e2e/armada.json
+++ b/cypress/fixtures/subdirectory-index/e2e/armada.json
@@ -1,0 +1,44 @@
+{
+  "configVersion": 1,
+  "timestamp": 1685455509636,
+  "index": "/index.html",
+  "assetGroups": [
+    {
+      "name": "main",
+      "installMode": "lazy",
+      "updateMode": "lazy",
+      "cacheQueryOptions": {
+        "ignoreVary": true
+      },
+      "urls": [
+        "/index.html",
+        "/blog/index.html"
+      ],
+      "patterns": []
+    }
+  ],
+  "dataGroups": [],
+  "hashTable": {
+    "/index.html": "25b7c0c49998c0e716456ed35dabfa1622253a69dbf21a6965b51ca6ef582f8c",
+    "/blog/index.html": "b56fe09ce18e961cba7c85257cdeada55a4ccf61c7f0db9f9b33c7af61a7d685"
+  },
+  "navigationUrls": [
+    {
+      "positive": true,
+      "regex": "^\\/.*$"
+    },
+    {
+      "positive": false,
+      "regex": "^\\/(?:.+\\/)?[^/]*\\.[^/]*$"
+    },
+    {
+      "positive": false,
+      "regex": "^\\/(?:.+\\/)?[^/]*__[^/]*$"
+    },
+    {
+      "positive": false,
+      "regex": "^\\/(?:.+\\/)?[^/]*__[^/]*\\/.*$"
+    }
+  ],
+  "navigationRequestStrategy": "performance"
+}

--- a/cypress/fixtures/subdirectory-index/e2e/blog/index.html
+++ b/cypress/fixtures/subdirectory-index/e2e/blog/index.html
@@ -1,0 +1,7 @@
+<html>
+
+<body>
+    <h1>blog index.html</h1>
+</body>
+
+</html>

--- a/cypress/fixtures/subdirectory-index/e2e/index.html
+++ b/cypress/fixtures/subdirectory-index/e2e/index.html
@@ -1,0 +1,10 @@
+<html>
+
+<body>
+  <h1>root index.html</h1>
+
+  <a href="/blog/">Blog with trailing slash</a>
+  <a href="/blog">Blog without trailing slash</a>
+</body>
+
+</html>

--- a/src/service-worker/src/app-version.ts
+++ b/src/service-worker/src/app-version.ts
@@ -67,9 +67,9 @@ export class AppVersion implements UpdateSource {
   }
 
   constructor(
-      private scope: ServiceWorkerGlobalScope, private adapter: Adapter, private database: Database,
-      idle: IdleScheduler, protected debugHandler: DebugHandler, readonly manifest: Manifest,
-      readonly manifestHash: string) {
+      private scope: ServiceWorkerGlobalScope, protected adapter: Adapter,
+      private database: Database, idle: IdleScheduler, protected debugHandler: DebugHandler,
+      readonly manifest: Manifest, readonly manifestHash: string) {
     // The hashTable within the manifest is an Object - convert it to a Map for easier lookups.
     Object.keys(manifest.hashTable).forEach(url => {
       this.hashTable.set(adapter.normalizeUrl(url), manifest.hashTable[url]);


### PR DESCRIPTION
The Angular service worker expects that every app is a true SPA, where the root `index.html` should be served whenever there's a navigation request for a route that doesn't exist. This behavior isn't always correct for Armada, because some projects will just be serving a static site that doesn't have any SPA-like routing behavior on the root `index.html` file.

In these cases, the expectation is that the web server (e.g. nginx, apache) will serve subdirectory index files whenever a request arrives for that index file's directory. For example, if `/blog/` is requested and there exists a file named `/blog/index.html`, nginx would serve that file. Prior to this PR the service worker would just serve `/index.html`, now it figures out that `/blog/index.html` actually exists and goes ahead and serves it.

Also included is an e2e test verifying the new functionality.