### PR TITLE
Handle subdirectory urls with querystrings

### DIFF
--- a/cypress/e2e/subdirectory-index.cy.ts
+++ b/cypress/e2e/subdirectory-index.cy.ts
@@ -12,14 +12,17 @@ it('subdirectories with index.html', () => {
   cy.visit(harness.domainNode.url);
   cy.get('h1').first().should('have.text', 'root index.html');
 
-  // With trailing slash
-  cy.get('a[href="/blog/"]').first().click();
-  cy.get('h1').first().should('have.text', 'blog index.html');
+  ['/blog',
+   '/blog?page=1',
+   '/blog/',
+   '/blog/?page=1',
+   '/blog/index.html',
+   '/blog/index.html?page=1',
+  ].forEach((href) => {
+    cy.get(`a[href="${href}"]`).first().click();
+    cy.get('h1').first().should('have.text', 'blog index.html');
 
-  cy.go('back');
-  cy.get('h1').first().should('have.text', 'root index.html');
-
-  // Without trailing slash
-  cy.get('a[href="/blog"]').first().click();
-  cy.get('h1').first().should('have.text', 'blog index.html');
+    cy.go('back');
+    cy.get('h1').first().should('have.text', 'root index.html');
+  });
 });

--- a/cypress/fixtures/subdirectory-index/e2e/armada.json
+++ b/cypress/fixtures/subdirectory-index/e2e/armada.json
@@ -1,6 +1,6 @@
 {
   "configVersion": 1,
-  "timestamp": 1685455509636,
+  "timestamp": 1685474855503,
   "index": "/index.html",
   "assetGroups": [
     {
@@ -19,7 +19,7 @@
   ],
   "dataGroups": [],
   "hashTable": {
-    "/index.html": "25b7c0c49998c0e716456ed35dabfa1622253a69dbf21a6965b51ca6ef582f8c",
+    "/index.html": "314441c59eeb9b31c910047c62dbe8f3c5633554ac2b5f345e47f96ee123c540",
     "/blog/index.html": "b56fe09ce18e961cba7c85257cdeada55a4ccf61c7f0db9f9b33c7af61a7d685"
   },
   "navigationUrls": [

--- a/cypress/fixtures/subdirectory-index/e2e/index.html
+++ b/cypress/fixtures/subdirectory-index/e2e/index.html
@@ -3,8 +3,12 @@
 <body>
   <h1>root index.html</h1>
 
-  <a href="/blog/">Blog with trailing slash</a>
-  <a href="/blog">Blog without trailing slash</a>
+  <a href="/blog">/blog</a>
+  <a href="/blog?page=1">/blog?page=1</a>
+  <a href="/blog/">/blog/</a>
+  <a href="/blog/?page=1">/blog/?page=1</a>
+  <a href="/blog/index.html">/blog/index.html</a>
+  <a href="/blog/index.html?page=1">/blog/index.html?page=1</a>
 </body>
 
 </html>

--- a/src/service-worker/src/armada/app-version.ts
+++ b/src/service-worker/src/armada/app-version.ts
@@ -1,4 +1,5 @@
 import {Adapter} from '../adapter';
+import {NormalizedUrl} from '../api';
 import {AppVersion} from '../app-version';
 import {Database} from '../database';
 import {DebugHandler} from '../debug';
@@ -61,8 +62,9 @@ export class ArmadaAppVersion extends AppVersion {
     // serve that index file instead of the root index.html (which is the default behavior whenever
     // there's a navigation request for a file that doesn't exist in the hash table).
     if (this.isNavigationRequest(req)) {
-      const indexUrl = req.url + (req.url.endsWith('/') ? '' : '/') + 'index.html';
-      if (this.hashTable.has(this.adapter.normalizeUrl(indexUrl))) {
+      const url = this.adapter.normalizeUrl(req.url);
+      const indexUrl = url + (url.endsWith('/') ? '' : '/') + 'index.html';
+      if (this.hashTable.has(indexUrl as NormalizedUrl)) {
         return super.handleFetch(this.adapter.newRequest(indexUrl), event);
       }
     }


### PR DESCRIPTION
#2 did not correctly handle cases like `/blog?page=1`, this fixes that.